### PR TITLE
Support for ServicePrincipal AAD token while accessing AKV

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -147,7 +147,6 @@ size_t Util::CurlWriteCallback(char *data, size_t size, size_t nmemb, std::strin
 }
 
 /// Retrieve IMDS token retrieval URL for a resource url.
-/// If multiple identities are associated, client_id can be used to select one identity
 /// eg, "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net"};
 static inline std::string GetImdsTokenUrl(std::string url)
 {
@@ -156,7 +155,7 @@ static inline std::string GetImdsTokenUrl(std::string url)
     oss << "?api-version=" << Constants::IMDS_API_VERSION;
     oss << "&resource=" << Util::url_encode(url);
 
-    auto clientId = std::getenv("IMDS_CLIENT_ID");
+    auto client_id = std::getenv("IMDS_CLIENT_ID");
     if (!client_id.empty())
     {
         oss << "&client_id=" << client_id;
@@ -618,7 +617,11 @@ std::string Util::GetKeyVaultResponse(const std::string &requestUri,
     return responseStr;
 }
 
-bool Util::doSKR(const std::string &attestation_url, const std::string &nonce, std::string KEKUrl, EVP_PKEY **pkey, const AkvCredentialSource &akv_credential_source)
+bool Util::doSKR(const std::string &attestation_url,
+                 const std::string &nonce,
+                 std::string KEKUrl,
+                 EVP_PKEY **pkey,
+                 const Util::AkvCredentialSource &akv_credential_source)
 {
     TRACE_OUT("Entering Util::doSKR()");
 
@@ -628,10 +631,10 @@ bool Util::doSKR(const std::string &attestation_url, const std::string &nonce, s
         std::string access_token;
         switch (akv_credential_source)
         {
-        case AkvCredentialSource::EnvServicePrincipal:
+        case Util::AkvCredentialSource::EnvServicePrincipal:
             access_token = std::move(Util::GetAADToken());
             break;
-        case AkvCredentialSource::Imds:
+        case Util::AkvCredentialSource::Imds:
         default:
             access_token = std::move(Util::GetIMDSToken());
             break;
@@ -872,7 +875,7 @@ std::string Util::WrapKey(const std::string &attestation_url,
                           const std::string &nonce,
                           const std::string &sym_key,
                           const std::string &key_enc_key_url,
-                          const AkvCredentialSource &akv_credential_source)
+                          const Util::AkvCredentialSource &akv_credential_source)
 {
     TRACE_OUT("Entering Util::WrapKey()");
 
@@ -913,7 +916,7 @@ std::string Util::UnwrapKey(const std::string &attestation_url,
                             const std::string &nonce,
                             const std::string &wrapped_key_base64,
                             const std::string &key_enc_key_url,
-                            const AkvCredentialSource &akv_credential_source)
+                            const Util::AkvCredentialSource &akv_credential_source)
 {
     TRACE_OUT("Entering Util::UnwrapKey()");
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -214,11 +214,14 @@ std::string Util::GetIMDSToken(std::string client_id)
 
     curl_easy_cleanup(curl);
 
-    TRACE_OUT("Response: %s\n", responseStr.c_str());
+    json json_object = json::parse(responseStr.c_str());
+    std::string access_token = json_object["access_token"].get<std::string>();
+
+    TRACE_OUT("Response: %s\n", access_token.c_str());
 
     TRACE_OUT("Exiting Util::GetIMDSToken()");
 
-    return responseStr;
+    return access_token;
 }
 
 /// \copydoc Util::GetAADToken()
@@ -623,11 +626,10 @@ bool Util::doSKR(const std::string &attestation_url, const std::string &nonce, s
         std::string attest_token(Util::GetMAAToken(attestation_url, nonce));
         TRACE_OUT("MAA Token: %s", attest_token.c_str());
 
-        // std::string akvMsiToken = std::move(Util::GetIMDSToken(client_id));
-        std::string akvMsiToken = std::move(Util::GetAADToken());
-        TRACE_OUT("AkvMsiToken: %s", akvMsiToken.c_str());
-        json json_object = json::parse(akvMsiToken.c_str());
-        std::string access_token = json_object["access_token"].get<std::string>();
+        // std::string access_token = std::move(Util::GetIMDSToken(client_id));
+        std::string access_token = std::move(Util::GetAADToken());
+        TRACE_OUT("AkvMsiAccessToken: %s", access_token.c_str());
+
         std::string requestUri = Util::GetKeyVaultSKRurl(KEKUrl);
         std::string responseStr = Util::GetKeyVaultResponse(requestUri, access_token, attest_token, nonce);
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -214,10 +214,12 @@ std::string Util::GetIMDSToken()
 
     curl_easy_cleanup(curl);
 
+    TRACE_OUT("Response: %s\n", responseStr.c_str());
+
     json json_object = json::parse(responseStr.c_str());
     std::string access_token = json_object["access_token"].get<std::string>();
 
-    TRACE_OUT("Response: %s\n", access_token.c_str());
+    TRACE_OUT("Access Token: %s\n", access_token.c_str());
 
     TRACE_OUT("Exiting Util::GetIMDSToken()");
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -156,7 +156,7 @@ static inline std::string GetImdsTokenUrl(std::string url)
     oss << "&resource=" << Util::url_encode(url);
 
     auto client_id = std::getenv("IMDS_CLIENT_ID");
-    if (!client_id.empty())
+    if (client_id != nullptr && strlen(client_id) > 0)
     {
         oss << "&client_id=" << client_id;
     }
@@ -627,6 +627,9 @@ bool Util::doSKR(const std::string &attestation_url,
 
     try
     {
+        std::string attest_token(Util::GetMAAToken(attestation_url, nonce));
+        TRACE_OUT("MAA Token: %s", attest_token.c_str());
+
         // Get Akv access token either using IMDS or Service Principal
         std::string access_token;
         switch (akv_credential_source)

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -153,7 +153,7 @@ public:
     /// Retrieve MSI token from Service Principal Credentials available in the Environment Variables
     /// </summary>
     /// <returns>MSI token for the resource</returns>
-    static std::string Util::GetAADToken();
+    static std::string GetAADToken();
 
     /// <summary>
     /// Get attestation token from the attestation service.

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -149,6 +149,12 @@ public:
     /// <returns>MSI token for the resource</returns>
     static std::string GetIMDSToken(std::string client_id = "");
 
+    // <summary>
+    /// Retrieve MSI token from Service Principal Credentials available in the Environment Variables
+    /// </summary>
+    /// <returns>MSI token for the resource</returns>
+    static std::string Util::GetAADToken();
+
     /// <summary>
     /// Get attestation token from the attestation service.
     /// </summary>

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -145,9 +145,8 @@ public:
     /// <summary>
     /// Retrieve MSI token from IMDS servce
     /// </summary>
-    /// <param name="client_id">optional client_id of the managed identity if there are multiple associated with the node</param>
     /// <returns>MSI token for the resource</returns>
-    static std::string GetIMDSToken(std::string client_id = "");
+    static std::string GetIMDSToken();
 
     // <summary>
     /// Retrieve MSI token from Service Principal Credentials available in the Environment Variables
@@ -177,12 +176,12 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="KEKUrl">AKV URL of the key</param>
     /// <param name="pkey">OpenSSL key representation</param>
-    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
+    /// <param name="akv_credential_source">AkvCredentialSource type for accessing Key Vault</param>
     /// <returns>True if successful</returns>
     static bool doSKR(const std::string &attestation_url,
                       const std::string &nonce, std::string KEKUrl,
                       EVP_PKEY **pkey,
-                      const std::string &client_id);
+                      const AkvCredentialSource &akv_credential_source);
 
     /// <summary>
     /// Wrap the symmetric key with the public key of the key encryption key (KEK).
@@ -191,13 +190,13 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="plainText">Plain text symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
-    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
+    /// <param name="akv_credential_source">AkvCredentialSource type for accessing Key Vault</param>
     /// <returns>Wrapped key</returns>
     static std::string WrapKey(const std::string &attestation_url,
                                const std::string &nonce,
                                const std::string &plainText,
                                const std::string &key_enc_key,
-                               const std::string &client_id);
+                               const AkvCredentialSource &akv_credential_source);
 
     /// <summary>
     /// Unwrap the symmetric key using the private key of the key encryption key (KEK).
@@ -206,11 +205,11 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="cipherText">Wrapped symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
-    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
+    /// <param name="akv_credential_source">AkvCredentialSource type for accessing Key Vault</param>
     /// <returns>Plain text symmetric key</returns>
     static std::string UnwrapKey(const std::string &attestation_url,
                                  const std::string &nonce,
                                  const std::string &cipherText,
                                  const std::string &key_enc_key,
-                                 const std::string &client_id);
+                                 const AkvCredentialSource &akv_credential_source);
 };

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -74,6 +74,12 @@ inline static void OSSL_BN_TRACE_OUT(const BIGNUM *bn)
 class Util
 {
 public:
+    enum class AkvCredentialSource
+    {
+        Imds,
+        EnvServicePrincipal
+    };
+
     /// <summary>
     /// Convert a base64 encoded string to a vector of bytes.
     /// </summary>
@@ -181,7 +187,7 @@ public:
     static bool doSKR(const std::string &attestation_url,
                       const std::string &nonce, std::string KEKUrl,
                       EVP_PKEY **pkey,
-                      const AkvCredentialSource &akv_credential_source);
+                      const Util::AkvCredentialSource &akv_credential_source);
 
     /// <summary>
     /// Wrap the symmetric key with the public key of the key encryption key (KEK).
@@ -196,7 +202,7 @@ public:
                                const std::string &nonce,
                                const std::string &plainText,
                                const std::string &key_enc_key,
-                               const AkvCredentialSource &akv_credential_source);
+                               const Util::AkvCredentialSource &akv_credential_source);
 
     /// <summary>
     /// Unwrap the symmetric key using the private key of the key encryption key (KEK).
@@ -211,5 +217,5 @@ public:
                                  const std::string &nonce,
                                  const std::string &cipherText,
                                  const std::string &key_enc_key,
-                                 const AkvCredentialSource &akv_credential_source);
+                                 const Util::AkvCredentialSource &akv_credential_source);
 };

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -13,21 +13,6 @@ endif()
 
 add_definitions (-DPLATFORM_UNIX)
 
-include(FetchContent)
-FetchContent_Declare(
-    azuresdk
-    GIT_REPOSITORY      https://github.com/Azure/azure-sdk-for-cpp.git
-    GIT_TAG             azure-identity_1.5.0-beta.2
-)
-FetchContent_GetProperties(azuresdk)
-if(NOT azuresdk_POPULATED)
-    FetchContent_Populate(azuresdk)
-    # Adding all Azure SDK libraries
-    # add_subdirectory(${azuresdk_SOURCE_DIR} ${azuresdk_BINARY_DIR} EXCLUDE_FROM_ALL)
-    # Adding one Azure SDK Library only (Storage blobs)
-    add_subdirectory(${azuresdk_SOURCE_DIR}/sdk/identity/azure-identity ${azuresdk_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
-
 include_directories(
      /usr/include/azguestattestation1
      /usr/include/jsoncpp

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -29,4 +29,5 @@ add_executable(${CMAKE_PROJECT_TARGET}
     Main.cpp
 )
 
-target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp)
+find_package(azure-identity-cpp CONFIG REQUIRED)
+target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp Azure::azure-identity)

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -13,6 +13,21 @@ endif()
 
 add_definitions (-DPLATFORM_UNIX)
 
+include(FetchContent)
+FetchContent_Declare(
+    azuresdk
+    GIT_REPOSITORY      https://github.com/Azure/azure-sdk-for-cpp.git
+    GIT_TAG             azure-identity_1.5.0-beta.2
+)
+FetchContent_GetProperties(azuresdk)
+if(NOT azuresdk_POPULATED)
+    FetchContent_Populate(azuresdk)
+    # Adding all Azure SDK libraries
+    # add_subdirectory(${azuresdk_SOURCE_DIR} ${azuresdk_BINARY_DIR} EXCLUDE_FROM_ALL)
+    # Adding one Azure SDK Library only (Storage blobs)
+    add_subdirectory(${azuresdk_SOURCE_DIR}/sdk/identity/azure-identity ${azuresdk_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
+
 include_directories(
      /usr/include/azguestattestation1
      /usr/include/jsoncpp
@@ -30,4 +45,4 @@ add_executable(${CMAKE_PROJECT_TARGET}
 )
 
 find_package(azure-identity-cpp CONFIG REQUIRED)
-target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp Azure::azure-identity)
+target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp PRIVATE Azure::azure-identity)

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -29,5 +29,4 @@ add_executable(${CMAKE_PROJECT_TARGET}
     Main.cpp
 )
 
-find_package(azure-identity-cpp CONFIG REQUIRED)
-target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp PRIVATE Azure::azure-identity)
+target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp)

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -62,15 +62,15 @@ int main(int argc, char *argv[])
             TRACE_OUT("key_enc_key_url: %s", key_enc_key_url.c_str());
             break;
         case 'c':
-            if (optarg == 'imds')
+            if (strcmp(optarg, "imds") == 0)
             {
                 akv_credential_source = Util::AkvCredentialSource::Imds;
             }
-            else if (optarg == 'sp')
+            else if (strcmp(optarg, "sp") == 0)
             {
                 akv_credential_source = Util::AkvCredentialSource::EnvServicePrincipal;
             }
-            TRACE_OUT("akv_credential_source: %d", static_cast<int>(op));
+            TRACE_OUT("akv_credential_source: %d", static_cast<int>(akv_credential_source));
             break;
         case 'u':
             op = Operation::UnwrapKey;

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -22,7 +22,7 @@
 
 void usage(char *programName)
 {
-    printf("Usage: %s -a <attestation-endpoint> -n <optional-nonce> -k KEK -c <optional-imds-client-id> -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
+    printf("Usage: %s -a <attestation-endpoint> -n <optional-nonce> -k KEK -c (imds|sp) -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
 }
 
 enum class Operation

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
     std::string key_enc_key_url;
     std::string client_id;
     Operation op = Operation::None;
-    AkvCredentialSource akvCredentialSource = AkvCredential::EnvServicePrincipal;
+    AkvCredentialSource akvCredentialSource = AkvCredentialSource::EnvServicePrincipal;
 
     int opt;
     while ((opt = getopt(argc, argv, "a:n:k:c:s:uw")) != -1)

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -33,6 +33,12 @@ enum class Operation
     Undefined
 };
 
+enum class AkvCredentialSource
+{
+    IMDS,
+    EnvServicePrincipal
+};
+
 int main(int argc, char *argv[])
 {
     TRACE_OUT("Main started");
@@ -43,6 +49,7 @@ int main(int argc, char *argv[])
     std::string key_enc_key_url;
     std::string client_id;
     Operation op = Operation::None;
+    AkvCredentialSource akvCredentialSource = AkvCredential::EnvServicePrincipal;
 
     int opt;
     while ((opt = getopt(argc, argv, "a:n:k:c:s:uw")) != -1)

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -35,7 +35,7 @@ enum class Operation
 
 enum class AkvCredentialSource
 {
-    IMDS,
+    Imds,
     EnvServicePrincipal
 };
 
@@ -47,9 +47,8 @@ int main(int argc, char *argv[])
     std::string nonce;
     std::string sym_key;
     std::string key_enc_key_url;
-    std::string client_id;
     Operation op = Operation::None;
-    AkvCredentialSource akvCredentialSource = AkvCredentialSource::EnvServicePrincipal;
+    AkvCredentialSource akv_credential_source = AkvCredentialSource::Imds;
 
     int opt;
     while ((opt = getopt(argc, argv, "a:n:k:c:s:uw")) != -1)
@@ -69,8 +68,16 @@ int main(int argc, char *argv[])
             TRACE_OUT("key_enc_key_url: %s", key_enc_key_url.c_str());
             break;
         case 'c':
-            client_id.assign(optarg);
-            TRACE_OUT("client_id: %s", client_id.c_str());
+            switch (optarg)
+            {
+            case "imds":
+                akv_credential_source = AkvCredentialSource::Imds;
+                break;
+            case "sp":
+                akv_credential_source = AkvCredentialSource::EnvServicePrincipal;
+                break;
+            }
+            TRACE_OUT("akv_credential_source: %d", static_cast<int>(op));
             break;
         case 'u':
             op = Operation::UnwrapKey;
@@ -99,11 +106,11 @@ int main(int argc, char *argv[])
         switch (op)
         {
         case Operation::WrapKey:
-            result = Util::WrapKey(attestation_url, nonce, sym_key, key_enc_key_url, client_id);
+            result = Util::WrapKey(attestation_url, nonce, sym_key, key_enc_key_url, akv_credential_source);
             std::cout << result << std::endl;
             break;
         case Operation::UnwrapKey:
-            result = Util::UnwrapKey(attestation_url, nonce, sym_key, key_enc_key_url, client_id);
+            result = Util::UnwrapKey(attestation_url, nonce, sym_key, key_enc_key_url, akv_credential_source);
             std::cout << result << std::endl;
             break;
         default:

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -33,12 +33,6 @@ enum class Operation
     Undefined
 };
 
-enum class AkvCredentialSource
-{
-    Imds,
-    EnvServicePrincipal
-};
-
 int main(int argc, char *argv[])
 {
     TRACE_OUT("Main started");
@@ -48,7 +42,7 @@ int main(int argc, char *argv[])
     std::string sym_key;
     std::string key_enc_key_url;
     Operation op = Operation::None;
-    AkvCredentialSource akv_credential_source = AkvCredentialSource::Imds;
+    Util::AkvCredentialSource akv_credential_source = Util::AkvCredentialSource::Imds;
 
     int opt;
     while ((opt = getopt(argc, argv, "a:n:k:c:s:uw")) != -1)
@@ -71,10 +65,10 @@ int main(int argc, char *argv[])
             switch (optarg)
             {
             case "imds":
-                akv_credential_source = AkvCredentialSource::Imds;
+                akv_credential_source = Util::AkvCredentialSource::Imds;
                 break;
             case "sp":
-                akv_credential_source = AkvCredentialSource::EnvServicePrincipal;
+                akv_credential_source = Util::AkvCredentialSource::EnvServicePrincipal;
                 break;
             }
             TRACE_OUT("akv_credential_source: %d", static_cast<int>(op));

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -62,14 +62,13 @@ int main(int argc, char *argv[])
             TRACE_OUT("key_enc_key_url: %s", key_enc_key_url.c_str());
             break;
         case 'c':
-            switch (optarg)
+            if (optarg == 'imds')
             {
-            case "imds":
                 akv_credential_source = Util::AkvCredentialSource::Imds;
-                break;
-            case "sp":
+            }
+            else if (optarg == 'sp')
+            {
                 akv_credential_source = Util::AkvCredentialSource::EnvServicePrincipal;
-                break;
             }
             TRACE_OUT("akv_credential_source: %d", static_cast<int>(op));
             break;

--- a/cvm-securekey-release-app/README.md
+++ b/cvm-securekey-release-app/README.md
@@ -92,8 +92,14 @@ Optional Arguments
 sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -n "<some-identifier-per-maa-request>" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s <copy_base64_from_previous_run> -u
 ```
 
-- `-c`: If multiple managed identities are associated with the Confidential VM, `client_id` can be used to get the IMDS token for a selected identity
+- `-c (imds|sp)`: Override the credentials source provider for accessing AKV
 
-```sh
-sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -c "<some-azure-managed-identity-client_id>" -s "<copy_base64_from_previous_run>" -u
-```
+  - `imds`: If multiple managed identities are associated with the Confidential VM, `IMDS_CLIENT_ID` environment variable can be used to get the IMDS token for a selected identity
+
+  - `sp`: If a custom service principal credentials needs to be used, `AKV_SKR_CLIENT_ID`, `AKV_SKR_CLIENT_SECRET` and `AKV_SKR_TENANT_ID` environment variables can be provided
+
+  Example:
+
+  ```sh
+  sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -c "sp" -s "<copy_base64_from_previous_run>" -u
+  ```


### PR DESCRIPTION
- Adds support to use a custom Service Principal for accessing AKV 
- Modifies existing support for selecting IMDS `client_id` by reading the value from an environment variable instead of reading it from arg